### PR TITLE
V3 portfolio as img tags

### DIFF
--- a/src/client/components/Portfolio/PortfolioDetailImage.tsx
+++ b/src/client/components/Portfolio/PortfolioDetailImage.tsx
@@ -6,9 +6,6 @@ import { borderedImage } from '../../styles/extensions';
 interface Props {
   className?: string;
   imagePath: PortfolioImage;
-  featured?: boolean;
-  size?: string;
-  position?: string;
 }
 
 export const PortfolioDetailImage: React.SFC<Props> = (props) => {

--- a/src/client/components/Portfolio/PortfolioGallery.tsx
+++ b/src/client/components/Portfolio/PortfolioGallery.tsx
@@ -46,4 +46,5 @@ export default styled(PortfolioGallery)`
   list-style-type: none;
   grid-template-columns: repeat(auto-fit, minmax(${pxToRem(GALLERY.minItemSize)}, 1fr));
   grid-auto-flow: dense;
+  grid-auto-rows: ${pxToRem(GALLERY.minItemSize)};
 `;

--- a/src/client/components/Portfolio/PortfolioGallery.tsx
+++ b/src/client/components/Portfolio/PortfolioGallery.tsx
@@ -20,13 +20,18 @@ export const PortfolioGallery: React.SFC<Props> = (props) => {
   const { items, tag: Tag, ...rest } = props as Props & DefaultProps;
   return (
     <Tag {...rest}>
-      {items.map(item => (
-        <GalleryItem key={item.id} featured={item.featured}>
-          <GalleryLink to={`/portfolio/${item.id}`} featured={item.featured}>
-            <Item {...item} />
-          </GalleryLink>
-        </GalleryItem>
-      ))}
+      {items.map((item) => {
+        const row = item.meta && item.meta.thumb && item.meta.thumb.row;
+        const column = item.meta && item.meta.thumb && item.meta.thumb.column;
+
+        return (
+          <GalleryItem key={item.id} row={row} column={column}>
+            <GalleryLink to={`/portfolio/${item.id}`}>
+              <Item {...item} />
+            </GalleryLink>
+          </GalleryItem>
+        );
+      })}
     </Tag>
   );
 };

--- a/src/client/components/Portfolio/PortfolioGalleryItem.tsx
+++ b/src/client/components/Portfolio/PortfolioGalleryItem.tsx
@@ -25,13 +25,12 @@ GalleryItem.defaultProps = {
 GalleryItem.displayName = 'PortfolioGallery.Item';
 
 export default styled(GalleryItem)`
-  display: flex;
   padding: ${pxToRem(GALLERY.itemPadding)};
   ${(props) => {
     return props.featured ? `
       @media(min-width: ${pxToRem(GALLERY.fullSize)}) {
-        grid-column: auto / span 2;
-        grid-row: auto / span 2;
+        grid-column: span 2;
+        grid-row: span 2;
       }
     ` : '';
   }}

--- a/src/client/components/Portfolio/PortfolioGalleryItem.tsx
+++ b/src/client/components/Portfolio/PortfolioGalleryItem.tsx
@@ -5,7 +5,8 @@ import { GALLERY } from '../../styles/vars';
 
 interface Props {
   className?: string;
-  featured?: boolean;
+  row?: string;
+  column?: string;
   tag?: Tag;
 }
 
@@ -14,7 +15,7 @@ interface DefaultProps {
 }
 
 export const GalleryItem: React.SFC<Props> = (props) => {
-  const { tag: Tag, featured, ...rest } = props as Props & DefaultProps;
+  const { tag: Tag, row, column, ...rest } = props as Props & DefaultProps;
   return <Tag {...rest} />;
 };
 
@@ -27,11 +28,14 @@ GalleryItem.displayName = 'PortfolioGallery.Item';
 export default styled(GalleryItem)`
   padding: ${pxToRem(GALLERY.itemPadding)};
   ${(props) => {
-    return props.featured ? `
+    let styles = props.column ? `
       @media(min-width: ${pxToRem(GALLERY.fullSize)}) {
-        grid-column: span 2;
-        grid-row: span 2;
+        grid-column: ${props.column};
       }
     ` : '';
+    styles = `${styles}${props.row ? `
+      grid-row: ${props.row};
+    ` : ''}`;
+    return styles;
   }}
 `;

--- a/src/client/components/Portfolio/PortfolioGalleryLink.tsx
+++ b/src/client/components/Portfolio/PortfolioGalleryLink.tsx
@@ -5,13 +5,11 @@ import { pxToRem } from '../../styles/utils';
 import { GALLERY } from '../../styles/vars';
 
 interface Props {
-  featured?: boolean;
   to: string;
 }
 
 export const PortfolioGalleryLink: React.SFC<Props> = (props) => {
-  const { featured, ...rest } = props;
-  return <Link {...rest} />;
+  return <Link {...props} />;
 };
 
 PortfolioGalleryLink.displayName = 'PortfolioGallery.Link';

--- a/src/client/components/Portfolio/PortfolioGalleryLink.tsx
+++ b/src/client/components/Portfolio/PortfolioGalleryLink.tsx
@@ -17,18 +17,12 @@ export const PortfolioGalleryLink: React.SFC<Props> = (props) => {
 PortfolioGalleryLink.displayName = 'PortfolioGallery.Link';
 
 export default styled(PortfolioGalleryLink)`
-  position: relative;
+  display: block;
   overflow: hidden;
+  height: 100%;
   border: 10px solid #d4cfd1;
   border-radius: 3px;
   background-color: #e0dcde;
-  width: 100%;
-  min-height: ${pxToRem(GALLERY.minItemSize)};
-  ${props => props.featured ? `
-  @media(min-width: ${pxToRem(GALLERY.fullSize)}) {
-    height: 100%;
-  }
-  ` : ''}
   transition: transform 0.2s;
 
   &:hover {

--- a/src/client/components/Portfolio/PortfolioItem.tsx
+++ b/src/client/components/Portfolio/PortfolioItem.tsx
@@ -33,8 +33,10 @@ const Item: React.SFC<Props> = (props) => {
         className={props.className}
         imagePath={preferredImagePath}
         featured={props.featured}
-        size={props.meta && props.meta.thumb && props.meta.thumb.size}
+        fit={props.meta && props.meta.thumb && props.meta.thumb.fit}
+        alt={props.title}
         position={props.meta && props.meta.thumb && props.meta.thumb.position}
+
       />
     );
   }

--- a/src/client/components/Portfolio/PortfolioItem.tsx
+++ b/src/client/components/Portfolio/PortfolioItem.tsx
@@ -12,7 +12,6 @@ interface Props {
   tags: string[];
   svgSource?: string;
   imagePaths: PortfolioImage[];
-  featured?: boolean;
 }
 
 const Item: React.SFC<Props> = (props) => {
@@ -25,14 +24,13 @@ const Item: React.SFC<Props> = (props) => {
     );
   }
 
-  const preferredImagePath = getImagePath(props.imagePaths, props.featured);
+  const preferredImagePath = getImagePath(props.imagePaths);
 
   if (preferredImagePath) {
     return (
       <PortfolioItemImage
         className={props.className}
         imagePath={preferredImagePath}
-        featured={props.featured}
         fit={props.meta && props.meta.thumb && props.meta.thumb.fit}
         alt={props.title}
         position={props.meta && props.meta.thumb && props.meta.thumb.position}

--- a/src/client/components/Portfolio/PortfolioItemImage.tsx
+++ b/src/client/components/Portfolio/PortfolioItemImage.tsx
@@ -4,14 +4,13 @@ import styled from 'styled-components';
 interface Props {
   className?: string;
   imagePath: string;
-  featured?: boolean;
   fit?: string;
   position?: string;
   alt: string;
 }
 
 const PortfolioItemImage: React.SFC<Props> = (props) => {
-  const { imagePath, featured, fit, position, ...rest } = props;
+  const { imagePath, fit, position, ...rest } = props;
   return (
     <img src={imagePath} {...rest} />
   );
@@ -31,7 +30,7 @@ export default styled(PortfolioItemImage)`
   object-fit: cover;
   object-position: ${props => props.position ? props.position : '50% 0'};
   transform: scale(1.05);
-  filter: ${props => !props.featured ? `grayscale(0.85)` : 'grayscale(0.65)'};
+  filter: grayscale(0.65);
   transition: filter 0.2s, transform 0.2s;
 
   &:hover {

--- a/src/client/components/Portfolio/PortfolioItemImage.tsx
+++ b/src/client/components/Portfolio/PortfolioItemImage.tsx
@@ -7,7 +7,7 @@ interface Props {
   featured?: boolean;
   size?: string;
   position?: string;
-  tag?: Tag;
+  tag?: Tag; // remove me?
 }
 
 interface DefaultProps {
@@ -16,7 +16,9 @@ interface DefaultProps {
 
 const PortfolioItemImage: React.SFC<Props> = (props) => {
   const { tag: Tag, imagePath, featured, size, position, ...rest } = props as Props & DefaultProps;
-  return <Tag {...rest}/>;
+  return (
+    <img src={imagePath} alt="FIXME" {...rest} />
+  );
 };
 
 PortfolioItemImage.defaultProps = {
@@ -25,35 +27,41 @@ PortfolioItemImage.defaultProps = {
 
 PortfolioItemImage.displayName = 'PortfolioItemImage';
 
-const StyledPortfoioItemImage = styled(PortfolioItemImage)`
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  overflow: hidden;
-  background-image: ${props => `url('${props.imagePath}')`};
-  background-position: ${props => !props.featured ? `${props.position}` : 'center'};
-  width: 100%;
-  height: 100%;
-  background-size: ${(props) => {
-    if (props.size) {
-      return props.size;
-    }
-    return props.featured ? 'cover' : '90%';
-  }};
-  filter: ${props => !props.featured ? `grayscale(0.85)` : 'grayscale(0.65)'};
-  transition: filter 0.2s, transform 0.2s;
-  ${props => props.featured ? 'transform: scale(1.05);' : ''};
-
-  &:hover {
-    filter: grayscale(0);
-    transform: scale(1);
+export default styled(PortfolioItemImage)`
+  img {
+    object-fit: cover;
   }
 `;
 
-StyledPortfoioItemImage.defaultProps = {
-  position: '-20% -30%',
-};
+// const StyledPortfoioItemImage = styled(PortfolioItemImage)`
+//   position: absolute;
+//   top: 0;
+//   left: 0;
+//   right: 0;
+//   bottom: 0;
+//   overflow: hidden;
+//   background-image: ${props => `url('${props.imagePath}')`};
+//   background-position: ${props => !props.featured ? `${props.position}` : 'center'};
+//   width: 100%;
+//   height: 100%;
+//   background-size: ${(props) => {
+//     if (props.size) {
+//       return props.size;
+//     }
+//     return props.featured ? 'cover' : '90%';
+//   }};
+//   filter: ${props => !props.featured ? `grayscale(0.85)` : 'grayscale(0.65)'};
+//   transition: filter 0.2s, transform 0.2s;
+//   ${props => props.featured ? 'transform: scale(1.05);' : ''};
 
-export default StyledPortfoioItemImage;
+//   &:hover {
+//     filter: grayscale(0);
+//     transform: scale(1);
+//   }
+// `;
+
+// StyledPortfoioItemImage.defaultProps = {
+//   position: '-20% -30%',
+// };
+//
+// export default StyledPortfoioItemImage;

--- a/src/client/components/Portfolio/PortfolioItemImage.tsx
+++ b/src/client/components/Portfolio/PortfolioItemImage.tsx
@@ -5,63 +5,37 @@ interface Props {
   className?: string;
   imagePath: string;
   featured?: boolean;
-  size?: string;
+  fit?: string;
   position?: string;
-  tag?: Tag; // remove me?
-}
-
-interface DefaultProps {
-  tag: Tag;
+  alt: string;
 }
 
 const PortfolioItemImage: React.SFC<Props> = (props) => {
-  const { tag: Tag, imagePath, featured, size, position, ...rest } = props as Props & DefaultProps;
+  const { imagePath, featured, fit, position, ...rest } = props;
   return (
-    <img src={imagePath} alt="FIXME" {...rest} />
+    <img src={imagePath} {...rest} />
   );
 };
-
-PortfolioItemImage.defaultProps = {
-  tag: 'div',
-} as DefaultProps;
 
 PortfolioItemImage.displayName = 'PortfolioItemImage';
 
 export default styled(PortfolioItemImage)`
-  img {
-    object-fit: cover;
+  ${(props) => {
+    if (props.position !== undefined) {
+      console.log('props', props);
+    }
+    return '';
+  }}
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: ${props => props.position ? props.position : '50% 0'};
+  transform: scale(1.05);
+  filter: ${props => !props.featured ? `grayscale(0.85)` : 'grayscale(0.65)'};
+  transition: filter 0.2s, transform 0.2s;
+
+  &:hover {
+    filter: grayscale(0);
+    transform: scale(1);
   }
 `;
-
-// const StyledPortfoioItemImage = styled(PortfolioItemImage)`
-//   position: absolute;
-//   top: 0;
-//   left: 0;
-//   right: 0;
-//   bottom: 0;
-//   overflow: hidden;
-//   background-image: ${props => `url('${props.imagePath}')`};
-//   background-position: ${props => !props.featured ? `${props.position}` : 'center'};
-//   width: 100%;
-//   height: 100%;
-//   background-size: ${(props) => {
-//     if (props.size) {
-//       return props.size;
-//     }
-//     return props.featured ? 'cover' : '90%';
-//   }};
-//   filter: ${props => !props.featured ? `grayscale(0.85)` : 'grayscale(0.65)'};
-//   transition: filter 0.2s, transform 0.2s;
-//   ${props => props.featured ? 'transform: scale(1.05);' : ''};
-
-//   &:hover {
-//     filter: grayscale(0);
-//     transform: scale(1);
-//   }
-// `;
-
-// StyledPortfoioItemImage.defaultProps = {
-//   position: '-20% -30%',
-// };
-//
-// export default StyledPortfoioItemImage;

--- a/src/client/components/Portfolio/PortfolioItemSVG.tsx
+++ b/src/client/components/Portfolio/PortfolioItemSVG.tsx
@@ -21,5 +21,6 @@ export default styled(PortfolioItemSVG)`
   &, svg {
     width: 100%;
     height: 100%;
+    object-fit: cover;
   }
 `;

--- a/src/client/styles/vars.ts
+++ b/src/client/styles/vars.ts
@@ -35,7 +35,7 @@ export const mediumWeight = 500;
 export const boldWeight = 600;
 
 export const GALLERY = Object.freeze({
-  itemPadding: 16,
+  itemPadding: 8,
   minItemSize: 300,
   fullSize: 800,
 });

--- a/src/client/utils/__tests__/portfolioImage.test.ts
+++ b/src/client/utils/__tests__/portfolioImage.test.ts
@@ -4,18 +4,18 @@ import {
 } from '../portfolioImage';
 
 describe('getImagePath', () => {
-  it('should prefer the large image path for featured images', () => {
+  it('should prefer the large image path', () => {
     const imagePaths: PortfolioImage[] = [{
       largeUrl: '/path/to/large.jpg',
       originalUrl: '/path/to/full.jpg',
       mediumUrl: '/path/to/medium.jpg',
     }];
 
-    const result = getImagePath(imagePaths, true);
+    const result = getImagePath(imagePaths);
     expect(result).toEqual('/path/to/large.jpg');
   });
 
-  it('should fall back to full when large is not available', () => {
+  it('should fall back to original when large is not available', () => {
     const imagePaths: PortfolioImage[] = [{
       originalUrl: '/path/to/full.jpg',
       mediumUrl: '/path/to/medium.jpg',

--- a/src/client/utils/portfolioImage.ts
+++ b/src/client/utils/portfolioImage.ts
@@ -1,4 +1,4 @@
-export const getImagePath = (imagePaths: PortfolioImage | PortfolioImage[], featured = false): string | undefined => {
+export const getImagePath = (imagePaths: PortfolioImage | PortfolioImage[]): string | undefined => {
   let path;
   if (Array.isArray(imagePaths)) {
     path = imagePaths[0];
@@ -10,7 +10,7 @@ export const getImagePath = (imagePaths: PortfolioImage | PortfolioImage[], feat
     return;
   }
 
-  if (featured && path.largeUrl) {
+  if (path.largeUrl) {
     return path.largeUrl;
   }
   if (path.originalUrl) {
@@ -19,7 +19,7 @@ export const getImagePath = (imagePaths: PortfolioImage | PortfolioImage[], feat
 };
 
 export const getImagePaths = (imagePaths: PortfolioImage[]): string[] => {
-  const partial = (path: PortfolioImage) => getImagePath(path, false);
+  const partial = (path: PortfolioImage) => getImagePath(path);
   return imagePaths.map(partial).filter(path => path !== undefined) as string[];
 };
 

--- a/src/server/data/portfolio.ts
+++ b/src/server/data/portfolio.ts
@@ -197,6 +197,9 @@ const PortfolioList: RawPortfolio[] = [
       stackDesign: false,
       websiteUrl: '',
       isSVG: false,
+      thumb: {
+        position: '50% 50%',
+      },
     },
     category: [
       'illustration',
@@ -310,6 +313,9 @@ const PortfolioList: RawPortfolio[] = [
       stackDesign: true,
       websiteUrl: '',
       isSVG: false,
+      thumb: {
+        position: '50% 50%',
+      },
     },
     category: [
       'flyers',
@@ -425,7 +431,7 @@ const PortfolioList: RawPortfolio[] = [
       websiteUrl: '',
       isSVG: false,
       thumb: {
-        size: 'contain',
+        fit: 'contain',
       },
     },
     category: [
@@ -471,6 +477,9 @@ const PortfolioList: RawPortfolio[] = [
       stackDesign: true,
       websiteUrl: '',
       isSVG: false,
+      thumb: {
+        position: '50% 50%',
+      },
     },
     category: [
       'flyers',
@@ -516,8 +525,7 @@ const PortfolioList: RawPortfolio[] = [
       websiteUrl: '',
       isSVG: false,
       thumb: {
-        size: '100%',
-        position: '0',
+        position: '50% 50%',
       },
     },
     category: [
@@ -875,6 +883,9 @@ const PortfolioList: RawPortfolio[] = [
       stackDesign: false,
       websiteUrl: '',
       isSVG: false,
+      thumb: {
+        position: '0 100%',
+      },
     },
     category: [
       'logos',

--- a/src/server/data/portfolio.ts
+++ b/src/server/data/portfolio.ts
@@ -18,13 +18,16 @@ const PortfolioList: RawPortfolio[] = [
     We encapsulated each of these UI components into React components that can be easily imported and customized by other developers.
     </p>
     `,
-    featured: true,
     meta: {
       stackDesign: false,
       websiteUrl: 'https://websdev.github.io/stencil/',
       isSVG: false,
       showTitle: false,
       highlightColor: 'rgba(60, 61, 66, 0.7)',
+      thumb: {
+        row: 'span 2',
+        column: 'span 2',
+      },
     },
     category: [
       'development',
@@ -146,12 +149,15 @@ const PortfolioList: RawPortfolio[] = [
   {
     title: 'EXBC @ BNG (Harry R4NS0M) web promo',
     description: 'EXBC at BNG with Harry Ransom web promo',
-    featured: true,
     meta: {
       stackDesign: true,
       websiteUrl: '',
       isSVG: false,
       highlightColor: 'rgba(142, 131, 232, 0.8)',
+      thumb: {
+        row: 'span 2',
+        column: 'span 2',
+      },
     },
     category: [
       'flyers',
@@ -218,12 +224,15 @@ const PortfolioList: RawPortfolio[] = [
   {
     title: 'Anarchostar',
     description: 'Web site for electronic music label Anarchostar',
-    featured: true,
     meta: {
       stackDesign: false,
       websiteUrl: 'http://projects.synbydesign.com/anarchostar/',
       isSVG: false,
       highlightColor: 'rgba(231, 26, 33, 0.8)',
+      thumb: {
+        row: 'span 4',
+        column: 'span 2',
+      },
     },
     category: [
       'web',
@@ -248,12 +257,15 @@ const PortfolioList: RawPortfolio[] = [
   {
     title: 'Just 4 Heads flyer',
     description: 'Just 4 Heads flyer',
-    featured: true,
     meta: {
       stackDesign: true,
       websiteUrl: '',
       isSVG: false,
       highlightColor: 'rgba(26, 189, 205, 0.8)',
+      thumb: {
+        row: 'span 2',
+        column: 'span 2',
+      },
       // TODO: Add dynamic page bg color: #FCFBFC
     },
     category: [
@@ -334,12 +346,15 @@ const PortfolioList: RawPortfolio[] = [
   {
     title: 'Petrol Distal flyer',
     description: 'Petrol Distal flyer',
-    featured: true,
     meta: {
       stackDesign: true,
       websiteUrl: '',
       isSVG: false,
       highlightColor: 'rgba(235, 193, 7, 0.6)',
+      thumb: {
+        row: 'span 2',
+        column: 'span 2',
+      },
     },
     category: [
       'flyers',
@@ -380,11 +395,14 @@ const PortfolioList: RawPortfolio[] = [
   {
     title: 'Deep Foc.us Takeover at Sonic Butter flyer',
     description: 'Deep Foc.us Takeover at Sonic Butter flyer',
-    featured: true,
     meta: {
       stackDesign: true,
       websiteUrl: '',
       isSVG: false,
+      thumb: {
+        row: 'span 2',
+        column: 'span 2',
+      },
     },
     category: [
       'flyers',
@@ -425,13 +443,14 @@ const PortfolioList: RawPortfolio[] = [
   {
     title: 'Expansion Barcast flyer',
     description: 'Expansion Barcast flyer',
-    featured: true,
     meta: {
       stackDesign: true,
       websiteUrl: '',
       isSVG: false,
       thumb: {
         fit: 'contain',
+        row: 'span 3',
+        column: 'span 2',
       },
     },
     category: [
@@ -563,6 +582,9 @@ const PortfolioList: RawPortfolio[] = [
       stackDesign: true,
       websiteUrl: '',
       isSVG: false,
+      thumb: {
+        row: 'span 2',
+      },
     },
     category: [
       'flyers',
@@ -585,6 +607,9 @@ const PortfolioList: RawPortfolio[] = [
       stackDesign: true,
       websiteUrl: '',
       isSVG: false,
+      thumb: {
+        column: 'span 2',
+      },
     },
     category: [
       'flyers',
@@ -639,6 +664,9 @@ const PortfolioList: RawPortfolio[] = [
       isSVG: false,
       detail: {
         grid: ['70%', '30%'],
+      },
+      thumb: {
+        row: 'span 3',
       },
     },
     category: [
@@ -744,6 +772,9 @@ const PortfolioList: RawPortfolio[] = [
       stackDesign: false,
       websiteUrl: 'http://projects.synbydesign.com/sagedragon/',
       isSVG: false,
+      thumb: {
+        row: 'span 3',
+      },
     },
     category: [
       'web',

--- a/src/server/services/__tests__/__snapshots__/portfolioService.test.ts.snap
+++ b/src/server/services/__tests__/__snapshots__/portfolioService.test.ts.snap
@@ -14,7 +14,6 @@ Array [
     We encapsulated each of these UI components into React components that can be easily imported and customized by other developers.
     </p>
     ",
-    "featured": true,
     "id": "stencil",
     "imagePaths": Array [
       Object {
@@ -82,6 +81,10 @@ Array [
       "isSVG": false,
       "showTitle": false,
       "stackDesign": false,
+      "thumb": Object {
+        "column": "span 2",
+        "row": "span 2",
+      },
       "websiteUrl": "https://websdev.github.io/stencil/",
     },
     "tags": Array [
@@ -285,7 +288,6 @@ Array [
       "flyers",
     ],
     "description": "EXBC at BNG with Harry Ransom web promo",
-    "featured": true,
     "id": "exbc-bng-harry-r-4-ns-0-m-web-promo",
     "imagePaths": Array [
       Object {
@@ -302,6 +304,10 @@ Array [
       "highlightColor": "rgba(142, 131, 232, 0.8)",
       "isSVG": false,
       "stackDesign": true,
+      "thumb": Object {
+        "column": "span 2",
+        "row": "span 2",
+      },
       "websiteUrl": "",
     },
     "tags": Array [],
@@ -353,6 +359,9 @@ Array [
     "meta": Object {
       "isSVG": false,
       "stackDesign": false,
+      "thumb": Object {
+        "position": "50% 50%",
+      },
       "websiteUrl": "",
     },
     "tags": Array [],
@@ -363,7 +372,6 @@ Array [
       "web",
     ],
     "description": "Web site for electronic music label Anarchostar",
-    "featured": true,
     "id": "anarchostar",
     "imagePaths": Array [
       Object {
@@ -380,6 +388,10 @@ Array [
       "highlightColor": "rgba(231, 26, 33, 0.8)",
       "isSVG": false,
       "stackDesign": false,
+      "thumb": Object {
+        "column": "span 2",
+        "row": "span 4",
+      },
       "websiteUrl": "http://projects.synbydesign.com/anarchostar/",
     },
     "tags": Array [
@@ -396,7 +408,6 @@ Array [
       "flyers",
     ],
     "description": "Just 4 Heads flyer",
-    "featured": true,
     "id": "just-4-heads-flyer",
     "imagePaths": Array [
       Object {
@@ -430,6 +441,10 @@ Array [
       "highlightColor": "rgba(26, 189, 205, 0.8)",
       "isSVG": false,
       "stackDesign": true,
+      "thumb": Object {
+        "column": "span 2",
+        "row": "span 2",
+      },
       "websiteUrl": "",
     },
     "tags": Array [],
@@ -480,6 +495,9 @@ Array [
     "meta": Object {
       "isSVG": false,
       "stackDesign": true,
+      "thumb": Object {
+        "position": "50% 50%",
+      },
       "websiteUrl": "",
     },
     "tags": Array [],
@@ -490,7 +508,6 @@ Array [
       "flyers",
     ],
     "description": "Petrol Distal flyer",
-    "featured": true,
     "id": "petrol-distal-flyer",
     "imagePaths": Array [
       Object {
@@ -507,6 +524,10 @@ Array [
       "highlightColor": "rgba(235, 193, 7, 0.6)",
       "isSVG": false,
       "stackDesign": true,
+      "thumb": Object {
+        "column": "span 2",
+        "row": "span 2",
+      },
       "websiteUrl": "",
     },
     "tags": Array [],
@@ -542,7 +563,6 @@ Array [
       "flyers",
     ],
     "description": "Deep Foc.us Takeover at Sonic Butter flyer",
-    "featured": true,
     "id": "deep-foc-us-takeover-at-sonic-butter-flyer",
     "imagePaths": Array [
       Object {
@@ -558,6 +578,10 @@ Array [
     "meta": Object {
       "isSVG": false,
       "stackDesign": true,
+      "thumb": Object {
+        "column": "span 2",
+        "row": "span 2",
+      },
       "websiteUrl": "",
     },
     "tags": Array [],
@@ -593,7 +617,6 @@ Array [
       "flyers",
     ],
     "description": "Expansion Barcast flyer",
-    "featured": true,
     "id": "expansion-barcast-flyer",
     "imagePaths": Array [
       Object {
@@ -610,7 +633,9 @@ Array [
       "isSVG": false,
       "stackDesign": true,
       "thumb": Object {
-        "size": "contain",
+        "column": "span 2",
+        "fit": "contain",
+        "row": "span 3",
       },
       "websiteUrl": "",
     },
@@ -662,6 +687,9 @@ Array [
     "meta": Object {
       "isSVG": false,
       "stackDesign": true,
+      "thumb": Object {
+        "position": "50% 50%",
+      },
       "websiteUrl": "",
     },
     "tags": Array [],
@@ -730,8 +758,7 @@ Array [
       "isSVG": false,
       "stackDesign": false,
       "thumb": Object {
-        "position": "0",
-        "size": "100%",
+        "position": "50% 50%",
       },
       "websiteUrl": "",
     },
@@ -758,6 +785,9 @@ Array [
     "meta": Object {
       "isSVG": false,
       "stackDesign": true,
+      "thumb": Object {
+        "row": "span 2",
+      },
       "websiteUrl": "",
     },
     "tags": Array [],
@@ -792,6 +822,9 @@ Array [
     "meta": Object {
       "isSVG": false,
       "stackDesign": true,
+      "thumb": Object {
+        "column": "span 2",
+      },
       "websiteUrl": "",
     },
     "tags": Array [],
@@ -814,7 +847,6 @@ Array [
     We encapsulated each of these UI components into React components that can be easily imported and customized by other developers.
     </p>
     ",
-    "featured": true,
     "id": "stencil",
     "imagePaths": Array [
       Object {
@@ -882,6 +914,10 @@ Array [
       "isSVG": false,
       "showTitle": false,
       "stackDesign": false,
+      "thumb": Object {
+        "column": "span 2",
+        "row": "span 2",
+      },
       "websiteUrl": "https://websdev.github.io/stencil/",
     },
     "tags": Array [
@@ -1085,7 +1121,6 @@ Array [
       "flyers",
     ],
     "description": "EXBC at BNG with Harry Ransom web promo",
-    "featured": true,
     "id": "exbc-bng-harry-r-4-ns-0-m-web-promo",
     "imagePaths": Array [
       Object {
@@ -1102,6 +1137,10 @@ Array [
       "highlightColor": "rgba(142, 131, 232, 0.8)",
       "isSVG": false,
       "stackDesign": true,
+      "thumb": Object {
+        "column": "span 2",
+        "row": "span 2",
+      },
       "websiteUrl": "",
     },
     "tags": Array [],
@@ -1153,6 +1192,9 @@ Array [
     "meta": Object {
       "isSVG": false,
       "stackDesign": false,
+      "thumb": Object {
+        "position": "50% 50%",
+      },
       "websiteUrl": "",
     },
     "tags": Array [],
@@ -1168,7 +1210,6 @@ Array [
       "web",
     ],
     "description": "Web site for electronic music label Anarchostar",
-    "featured": true,
     "id": "anarchostar",
     "imagePaths": Array [
       Object {
@@ -1185,6 +1226,10 @@ Array [
       "highlightColor": "rgba(231, 26, 33, 0.8)",
       "isSVG": false,
       "stackDesign": false,
+      "thumb": Object {
+        "column": "span 2",
+        "row": "span 4",
+      },
       "websiteUrl": "http://projects.synbydesign.com/anarchostar/",
     },
     "tags": Array [
@@ -1201,7 +1246,6 @@ Array [
       "flyers",
     ],
     "description": "Just 4 Heads flyer",
-    "featured": true,
     "id": "just-4-heads-flyer",
     "imagePaths": Array [
       Object {
@@ -1235,6 +1279,10 @@ Array [
       "highlightColor": "rgba(26, 189, 205, 0.8)",
       "isSVG": false,
       "stackDesign": true,
+      "thumb": Object {
+        "column": "span 2",
+        "row": "span 2",
+      },
       "websiteUrl": "",
     },
     "tags": Array [],
@@ -1285,6 +1333,9 @@ Array [
     "meta": Object {
       "isSVG": false,
       "stackDesign": true,
+      "thumb": Object {
+        "position": "50% 50%",
+      },
       "websiteUrl": "",
     },
     "tags": Array [],
@@ -1295,7 +1346,6 @@ Array [
       "flyers",
     ],
     "description": "Petrol Distal flyer",
-    "featured": true,
     "id": "petrol-distal-flyer",
     "imagePaths": Array [
       Object {
@@ -1312,6 +1362,10 @@ Array [
       "highlightColor": "rgba(235, 193, 7, 0.6)",
       "isSVG": false,
       "stackDesign": true,
+      "thumb": Object {
+        "column": "span 2",
+        "row": "span 2",
+      },
       "websiteUrl": "",
     },
     "tags": Array [],
@@ -1382,6 +1436,9 @@ Array [
       },
       "isSVG": false,
       "stackDesign": false,
+      "thumb": Object {
+        "row": "span 3",
+      },
       "websiteUrl": "",
     },
     "tags": Array [
@@ -1508,6 +1565,9 @@ Array [
     "meta": Object {
       "isSVG": false,
       "stackDesign": false,
+      "thumb": Object {
+        "row": "span 3",
+      },
       "websiteUrl": "http://projects.synbydesign.com/sagedragon/",
     },
     "tags": Array [
@@ -1645,6 +1705,9 @@ Array [
     "meta": Object {
       "isSVG": false,
       "stackDesign": false,
+      "thumb": Object {
+        "position": "0 100%",
+      },
       "websiteUrl": "",
     },
     "tags": Array [],

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -18,6 +18,8 @@ type Tag = React.SFC<any> | React.ComponentClass<any> & string;
 interface PortfolioThumbMeta {
   fit?: 'cover' | 'contain' | 'fill' | 'inherit' | 'initial' | 'none' | 'scale-down' | 'unset';
   position?: string;
+  column?: string;
+  row?: string;
 }
 
 interface DetailMeta {
@@ -67,7 +69,6 @@ interface RawPortfolio {
   tags: string[];
   svgSource?: string;
   imagePaths: PortfolioImage[];
-  featured?: boolean;
 }
 
 interface Portfolio extends RawPortfolio {

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -16,7 +16,7 @@ declare module '*.svg' {
 type Tag = React.SFC<any> | React.ComponentClass<any> & string;
 
 interface PortfolioThumbMeta {
-  size?: string;
+  fit?: 'cover' | 'contain' | 'fill' | 'inherit' | 'initial' | 'none' | 'scale-down' | 'unset';
   position?: string;
 }
 


### PR DESCRIPTION
* Use `img` tag instead of CSS `background-image` on portfolio gallery for more accessible content
* Remove `featured` property in favor of custom `column` and `row` values