### PR TITLE
Create SVG Detail View

### DIFF
--- a/src/client/client.tsx
+++ b/src/client/client.tsx
@@ -10,8 +10,10 @@ import * as runtime from 'serviceworker-webpack-plugin/lib/runtime';
 import Routes from './Routes';
 import createStore from '../utils/createStore';
 
-if ('serviceWorker' in navigator) {
-  runtime.register();
+if (process.env.NODE_ENV !== 'development') {
+  if ('serviceWorker' in navigator) {
+    runtime.register();
+  }
 }
 
 const axiosInstance = axios.create({

--- a/src/client/components/Portfolio/PortfolioDetailSVG.tsx
+++ b/src/client/components/Portfolio/PortfolioDetailSVG.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import styled from 'styled-components';
+import * as tinyColor from 'tinycolor2';
+import PortfolioItemSVG from './PortfolioItemSVG';
 import { pxToRem } from '../../styles/utils';
 import { COLORS } from '../../styles/vars';
 
-interface Props {
+interface Props extends React.HTMLProps<HTMLElement> {
   className?: string;
   svgSource: string;
   tag?: Tag;
@@ -13,15 +15,27 @@ interface DefaultProps {
   tag: Tag;
 }
 
+const secondaryList = Array.from({ length: 3 }, (v, i) => i);
+
 export const PortfolioDetailSVG: React.SFC<Props> = props => {
   const { tag: Tag, className, svgSource, ...rest } = props as Props &
     DefaultProps;
   return (
-    <Tag
-      className={className}
-      dangerouslySetInnerHTML={{ __html: svgSource }}
-      {...rest}
-    />
+    <Tag className={className} {...rest}>
+      <PortfolioItemSVG
+        svgSource={svgSource}
+        className="portfolio-detail__svg portfolio-detail__svg--primary"
+      />
+      <div className="portfolio-detail__secondary">
+        {secondaryList.map(item => (
+          <PortfolioItemSVG
+            key={item}
+            svgSource={svgSource}
+            className="portfolio-detail__svg portfolio-detail__svg--secondary"
+          />
+        ))}
+      </div>
+    </Tag>
   );
 };
 
@@ -35,12 +49,35 @@ const StyledPortfolioDetailSVG = styled(PortfolioDetailSVG)`
   text-align: center;
   margin-top: ${pxToRem(50)};
 
-  svg {
+  .portfolio-detail__secondary {
+    max-width: ${pxToRem(960)};
+    margin: auto;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(${pxToRem(320)}, 1fr));
+  }
+
+  .portfolio-detail__svg {
     fill: ${COLORS.base};
     width: 100%;
     max-width: ${pxToRem(960)};
-    max-height: 80vh;
+    margin: auto;
+    padding: 1vw;
+
+    svg {
+      max-height: 80vh;
+    }
   }
+
+  ${secondaryList.map(
+    i =>
+      `
+      .portfolio-detail__svg--secondary:nth-child(${i + 1}) {
+        fill: ${tinyColor(COLORS.highlight)
+          .spin(90 * i)
+          .toString()};
+      }
+    `,
+  )};
 `;
 
 export default StyledPortfolioDetailSVG;

--- a/src/client/components/Portfolio/PortfolioDetailSVG.tsx
+++ b/src/client/components/Portfolio/PortfolioDetailSVG.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import styled from 'styled-components';
+import { pxToRem } from '../../styles/utils';
+import { COLORS } from '../../styles/vars';
+
+interface Props {
+  className?: string;
+  svgSource: string;
+  tag?: Tag;
+}
+
+interface DefaultProps {
+  tag: Tag;
+}
+
+export const PortfolioDetailSVG: React.SFC<Props> = props => {
+  const { tag: Tag, className, svgSource, ...rest } = props as Props &
+    DefaultProps;
+  return (
+    <Tag
+      className={className}
+      dangerouslySetInnerHTML={{ __html: svgSource }}
+      {...rest}
+    />
+  );
+};
+
+PortfolioDetailSVG.defaultProps = {
+  tag: 'article',
+} as DefaultProps;
+
+PortfolioDetailSVG.displayName = 'Portfolio.DetailSVG';
+
+const StyledPortfolioDetailSVG = styled(PortfolioDetailSVG)`
+  text-align: center;
+  margin-top: ${pxToRem(50)};
+
+  svg {
+    fill: ${COLORS.base};
+    width: 100%;
+    max-width: ${pxToRem(960)};
+    max-height: 80vh;
+  }
+`;
+
+export default StyledPortfolioDetailSVG;

--- a/src/client/components/Portfolio/PortfolioItemSVG.tsx
+++ b/src/client/components/Portfolio/PortfolioItemSVG.tsx
@@ -1,19 +1,31 @@
 import * as React from 'react';
 import styled from 'styled-components';
 
-interface Props {
+interface Props extends React.HTMLProps<HTMLElement> {
   className?: string;
   svgSource: string;
+  tag?: Tag;
+}
+
+interface DefaultProps {
+  tag: Tag;
 }
 
 const PortfolioItemSVG: React.SFC<Props> = props => {
+  const { tag: Tag, svgSource, className, ...rest } = props as Props &
+    DefaultProps;
   return (
-    <div
+    <Tag
       className={props.className}
       dangerouslySetInnerHTML={{ __html: props.svgSource }}
+      {...rest}
     />
   );
 };
+
+PortfolioItemSVG.defaultProps = {
+  tag: 'div',
+} as DefaultProps;
 
 PortfolioItemSVG.displayName = 'PortfolioItemSVG';
 

--- a/src/client/pages/PortfolioDetailPage.tsx
+++ b/src/client/pages/PortfolioDetailPage.tsx
@@ -7,6 +7,7 @@ import { fetchPortfolioDetail } from '../actions';
 import { ThunkActionCreator } from '../../types.d';
 import Header from '../components/HeaderOnline';
 import PortfolioDetailImage from '../components/Portfolio/PortfolioDetailImage';
+import PortfolioDetailSVG from '../components/Portfolio/PortfolioDetailSVG';
 import PortfolioDetailBackground from '../components/Portfolio/PortfolioDetailBackground';
 import PortfolioDetailGallery from '../components/Portfolio/PortfolioDetailGallery';
 import PortfolioDetailHero from '../components/Portfolio/PortfolioDetailHero';
@@ -34,6 +35,10 @@ export class PortfolioDetailPage extends React.Component<Props, {}> {
   }
 
   getDetailView(portfolio: Portfolio) {
+    if (portfolio.svgSource) {
+      return <PortfolioDetailSVG svgSource={portfolio.svgSource} />;
+    }
+
     const galleryImagesPaths = getGalleryImages(
       this.props.portfolio.imagePaths,
     );

--- a/src/server/data/portfolio.ts
+++ b/src/server/data/portfolio.ts
@@ -92,7 +92,7 @@ const PortfolioList: RawPortfolio[] = [
     ],
   },
   {
-    title: 'R.M.R. Software Solutions Logo',
+    title: 'RMR Software Solutions',
     meta: {
       stackDesign: false,
       websiteUrl: '',
@@ -138,18 +138,10 @@ const PortfolioList: RawPortfolio[] = [
           </g>
         </g>
       </svg>`,
-    imagePaths: [
-      {
-        originalUrl:
-          'http://www.synbydesign.com/wp/wp-content/uploads/2016/01/RMR-Logo-Final.svg',
-        title: '',
-        description: '',
-        priority: 0,
-      },
-    ],
+    imagePaths: [],
   },
   {
-    title: 'EXBC @ BNG (Harry R4NS0M) web promo',
+    title: 'EXBC at BNG Harry R4NS0M web promo',
     description: 'EXBC at BNG with Harry Ransom web promo',
     meta: {
       stackDesign: true,

--- a/src/server/services/__tests__/__snapshots__/portfolioService.test.ts.snap
+++ b/src/server/services/__tests__/__snapshots__/portfolioService.test.ts.snap
@@ -103,15 +103,8 @@ Object {
       "category": Array [
         "logos",
       ],
-      "id": "r-m-r-software-solutions-logo",
-      "imagePaths": Array [
-        Object {
-          "description": "",
-          "originalUrl": "http://www.synbydesign.com/wp/wp-content/uploads/2016/01/RMR-Logo-Final.svg",
-          "priority": 0,
-          "title": "",
-        },
-      ],
+      "id": "rmr-software-solutions",
+      "imagePaths": Array [],
       "meta": Object {
         "isSVG": true,
         "stackDesign": false,
@@ -286,14 +279,14 @@ Object {
         </g>
       </svg>",
       "tags": Array [],
-      "title": "R.M.R. Software Solutions Logo",
+      "title": "RMR Software Solutions",
     },
     Object {
       "category": Array [
         "flyers",
       ],
       "description": "EXBC at BNG with Harry Ransom web promo",
-      "id": "exbc-bng-harry-r-4-ns-0-m-web-promo",
+      "id": "exbc-at-bng-harry-r-4-ns-0-m-web-promo",
       "imagePaths": Array [
         Object {
           "description": "",
@@ -316,7 +309,7 @@ Object {
         "websiteUrl": "",
       },
       "tags": Array [],
-      "title": "EXBC @ BNG (Harry R4NS0M) web promo",
+      "title": "EXBC at BNG Harry R4NS0M web promo",
     },
     Object {
       "category": Array [
@@ -647,15 +640,8 @@ Object {
       "category": Array [
         "logos",
       ],
-      "id": "r-m-r-software-solutions-logo",
-      "imagePaths": Array [
-        Object {
-          "description": "",
-          "originalUrl": "http://www.synbydesign.com/wp/wp-content/uploads/2016/01/RMR-Logo-Final.svg",
-          "priority": 0,
-          "title": "",
-        },
-      ],
+      "id": "rmr-software-solutions",
+      "imagePaths": Array [],
       "meta": Object {
         "isSVG": true,
         "stackDesign": false,
@@ -830,14 +816,14 @@ Object {
         </g>
       </svg>",
       "tags": Array [],
-      "title": "R.M.R. Software Solutions Logo",
+      "title": "RMR Software Solutions",
     },
     Object {
       "category": Array [
         "flyers",
       ],
       "description": "EXBC at BNG with Harry Ransom web promo",
-      "id": "exbc-bng-harry-r-4-ns-0-m-web-promo",
+      "id": "exbc-at-bng-harry-r-4-ns-0-m-web-promo",
       "imagePaths": Array [
         Object {
           "description": "",
@@ -860,7 +846,7 @@ Object {
         "websiteUrl": "",
       },
       "tags": Array [],
-      "title": "EXBC @ BNG (Harry R4NS0M) web promo",
+      "title": "EXBC at BNG Harry R4NS0M web promo",
     },
     Object {
       "category": Array [

--- a/src/server/services/__tests__/portfolioService.test.ts
+++ b/src/server/services/__tests__/portfolioService.test.ts
@@ -111,8 +111,8 @@ describe('list', () => {
 
 describe('getById', () => {
   test('should return a portfolio item if a match is found', () => {
-    return getById('r-m-r-software-solutions-logo').then(result => {
-      expect((result as Portfolio).id).toBe('r-m-r-software-solutions-logo');
+    return getById('rmr-software-solutions').then(result => {
+      expect((result as Portfolio).id).toBe('rmr-software-solutions');
     });
   });
   test('should return undefined if a match is not found', () => {


### PR DESCRIPTION
Fixes #79 

* Only register service worker if in production mode - this avoids the problem of refreshing your page locally and not seeing changes w/o manually clearing cache storage
* Create a Detail SVG view that displays the SVG source and 3 secondary views of it in different colors
* Update `PortfolioItemSVG.tsx` to support dynamic `Tag` and spreading `...rest` html properties
* Remove reference to SVG hosted on wordpress
* Fix broken routes for RMR and Harry design - something about special characters was breaking these routes when refreshing the page on the detail view