### PR TITLE
Add scalable type size support to all type components

### DIFF
--- a/src/client/components/Hero.tsx
+++ b/src/client/components/Hero.tsx
@@ -18,7 +18,7 @@ interface Props {
 
 const Hero: React.SFC<Props> = ({ className }) => {
   return (
-    <TypeJumbo tag="div" className={className}>
+    <TypeJumbo tag="div" className={className} scale>
       <HeroCopy>
         <Muted>Freelance</Muted> <Highlighted>Developer</Highlighted>, Teacher
         &amp; Consultant

--- a/src/client/styles/mixins.ts
+++ b/src/client/styles/mixins.ts
@@ -36,5 +36,24 @@ export const type = (typeDef: TypeSize): string => {
   `;
 };
 
+export const scalableType = (
+  [maxSize, lineHeight]: TypeSize,
+  minSize: number = 16,
+) => {
+  const relativeScaler = 10;
+  return `
+    font-size: 10vw;
+    line-height: ${lineHeight};
+
+    @media(max-width: ${pxToRem(minSize * relativeScaler)}) {
+      font-size: ${pxToRem(minSize)};
+    }
+
+    @media(min-width: ${pxToRem(maxSize * relativeScaler)}) {
+      font-size: ${pxToRem(maxSize)};
+    }
+  `;
+};
+
 export const baseFont = () => `font-family: 'Source Sans Pro', sans-serif;`;
 export const headerFont = () => `font-family: 'Lato', sans-serif;`;

--- a/src/client/utils/makeTypeComponent.tsx
+++ b/src/client/utils/makeTypeComponent.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import styled, { StyledComponentClass } from 'styled-components';
-import { type } from '../styles/mixins';
+import { type, scalableType } from '../styles/mixins';
 
 export interface Props {
   className?: string;
   tag: Tag;
+  scale?: boolean;
 }
 
 interface ReturnType {
@@ -20,7 +21,7 @@ interface ReturnType {
 
 export default function makeTypeComponent(typeSize: TypeSize): ReturnType {
   const Type: React.SFC<Props> = props => {
-    const { tag: Tag, className, children, ...rest } = props;
+    const { tag: Tag, className, scale, children, ...rest } = props;
     return (
       <Tag className={className} {...rest}>
         {children}
@@ -31,7 +32,7 @@ export default function makeTypeComponent(typeSize: TypeSize): ReturnType {
   Type.displayName = `Type(${typeSize})`;
 
   const StyledType = styled(Type)`
-    ${type(typeSize)};
+    ${props => (props.scale ? scalableType(typeSize) : type(typeSize))};
   `;
 
   return {


### PR DESCRIPTION
Fixes #77 

* Adds `scalableType` mixin
* Implements `scalableType` as a prop `scalable` on all `Type` components
* Applies scaling to `JumboType` on `Hero`