### PR TITLE
General UI Clean up

### DIFF
--- a/src/client/components/Header.tsx
+++ b/src/client/components/Header.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import styled from 'styled-components';
 import HeaderContent from './HeaderContent';
-import { headerSpacing } from '../styles/vars';
 
 export interface Props extends React.HTMLProps<HTMLElement> {
   className?: string;
@@ -20,6 +19,4 @@ Header.displayName = 'Header';
 
 export default styled(Header)`
   background-color: rgba(255, 255, 255, 0.9);
-  margin-top: ${headerSpacing};
-  margin-bottom: ${headerSpacing};
 `;

--- a/src/client/components/HeaderContent.tsx
+++ b/src/client/components/HeaderContent.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react';
 import styled from 'styled-components';
 import { pxToRem } from '../styles/utils';
-import { maxWidth, horizontalPadding, MEDIA_QUERIES } from '../styles/vars';
+import {
+  maxWidth,
+  horizontalPadding,
+  MEDIA_QUERIES,
+  headerSpacing,
+} from '../styles/vars';
 
 interface Props {
   className?: string;
@@ -18,7 +23,7 @@ const StyledHeaderContent = styled(HeaderContent)`
   flex-direction: column;
   align-items: center;
   max-width: ${pxToRem(maxWidth)};
-  padding: 1rem ${pxToRem(horizontalPadding)};
+  padding: calc(1rem + ${headerSpacing}) ${pxToRem(horizontalPadding)};
   margin: auto;
 
   @media (min-width: ${pxToRem(MEDIA_QUERIES.large)}) {

--- a/src/client/components/HeaderContent.tsx
+++ b/src/client/components/HeaderContent.tsx
@@ -7,6 +7,7 @@ import {
   MEDIA_QUERIES,
   headerSpacing,
 } from '../styles/vars';
+import Nav from './Nav';
 
 interface Props {
   className?: string;
@@ -26,9 +27,17 @@ const StyledHeaderContent = styled(HeaderContent)`
   padding: calc(1rem + ${headerSpacing}) ${pxToRem(horizontalPadding)};
   margin: auto;
 
+  ${Nav} {
+    margin-top: 1rem;
+  }
+
   @media (min-width: ${pxToRem(MEDIA_QUERIES.large)}) {
     flex-direction: row;
     justify-content: space-between;
+
+    ${Nav} {
+      margin-top: 0;
+    }
   }
 `;
 

--- a/src/client/components/Meta.tsx
+++ b/src/client/components/Meta.tsx
@@ -8,6 +8,7 @@ const Meta: React.SFC<{}> = () => (
       property="og:title"
       content="Syn By Design: Eric Masiello's Portfolio"
     />
+    <meta name="apple-mobile-web-app-title" content="Syn By Design" />
   </Helmet>
 );
 

--- a/src/client/components/Meta.tsx
+++ b/src/client/components/Meta.tsx
@@ -5,10 +5,13 @@ const Meta: React.SFC<{}> = () => (
   <Helmet>
     <title>Syn By Design: Eric Masiello's Portfolio</title>
     <meta
+      name="og_title"
       property="og:title"
       content="Syn By Design: Eric Masiello's Portfolio"
     />
+    <meta name="og_site_name" property="og:site_name" content="Syn By Design" />
     <meta name="apple-mobile-web-app-title" content="Syn By Design" />
+    <meta name="apple-mobile-web-app-capable" content="no" />
   </Helmet>
 );
 

--- a/src/client/components/Nav.tsx
+++ b/src/client/components/Nav.tsx
@@ -17,7 +17,7 @@ const NavList = styled.ul`
 NavList.displayName = 'NavList';
 
 const NavListItem = styled.li`
-  padding: 1rem;
+  padding-right: 1rem;
   text-transform: uppercase;
   font-weight: ${BODY_WEIGHTS.bold};
 

--- a/src/client/components/Portfolio/PortfolioDetailBackground.tsx
+++ b/src/client/components/Portfolio/PortfolioDetailBackground.tsx
@@ -8,8 +8,6 @@ interface Props {
   styles?: BackgroundStyles;
 }
 
-const height = 600;
-
 const defaultStyles: BackgroundStyles = {
   filter: 'blur(1px) grayscale(70%) opacity(0.7)',
   backgroundPosition: '50%',
@@ -35,7 +33,8 @@ const StyledPortfolioDetailBackground = styled(PortfolioDetailBackground)`
       top: 0;
       left: 0;
       right: 0;
-      height: ${pxToRem(height)};
+      height: 100%;
+      max-height: 80vw;
       z-index: 1;
       background-image: url('${props.imagePath}');
       background-size: ${styles!.size};

--- a/src/client/components/Portfolio/PortfolioDetailHero.tsx
+++ b/src/client/components/Portfolio/PortfolioDetailHero.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import PortfolioDetailBackground from './PortfolioDetailBackground';
 import { pxToRem } from '../../styles/utils';
 import { pageContainer, visuallyHidden, type } from '../../styles/mixins';
-import { TYPE_SIZE, HEADER_WEIGHTS } from '../../styles/vars';
+import { TYPE_SIZE, HEADER_WEIGHTS, COLORS } from '../../styles/vars';
 import Type1 from '../Type1';
 
 interface TitleProps {
@@ -30,9 +30,16 @@ const StyledTitle = styled(Title)`
 `;
 
 const Description = styled.div`
+  margin-top: 2rem;
+
   &:first-line {
     ${type(TYPE_SIZE.t4)};
     font-weight: ${HEADER_WEIGHTS.medium};
+  }
+
+  blockquote {
+    border-left: 1px solid ${COLORS.base};
+    padding-left: 1rem;
   }
 `;
 

--- a/src/client/components/Portfolio/PortfolioDetailHero.tsx
+++ b/src/client/components/Portfolio/PortfolioDetailHero.tsx
@@ -4,6 +4,7 @@ import PortfolioDetailBackground from './PortfolioDetailBackground';
 import { pxToRem } from '../../styles/utils';
 import { pageContainer, visuallyHidden, type } from '../../styles/mixins';
 import { TYPE_SIZE, HEADER_WEIGHTS } from '../../styles/vars';
+import Type1 from '../Type1';
 
 const minHeight = 600;
 
@@ -12,16 +13,15 @@ interface TitleProps {
   hide?: boolean;
 }
 
-// FIXME: should use Type1 here but need to figure out how to pass down hidden attribute
 const Title: React.SFC<TitleProps> = ({
   className,
   children,
   hide,
   ...rest
 }) => (
-  <h1 className={className} hidden={hide} {...rest}>
+  <Type1 tag="h1" className={className} hidden={hide} {...rest}>
     {children}
-  </h1>
+  </Type1>
 );
 
 const StyledTitle = styled(Title)`

--- a/src/client/components/Portfolio/PortfolioDetailHero.tsx
+++ b/src/client/components/Portfolio/PortfolioDetailHero.tsx
@@ -6,8 +6,6 @@ import { pageContainer, visuallyHidden, type } from '../../styles/mixins';
 import { TYPE_SIZE, HEADER_WEIGHTS } from '../../styles/vars';
 import Type1 from '../Type1';
 
-const minHeight = 600;
-
 interface TitleProps {
   className?: string;
   hide?: boolean;
@@ -46,8 +44,10 @@ const Content = styled.div`
 `;
 
 const HeroImageContainer = styled.div`
-  min-height: ${pxToRem(minHeight)};
   position: relative;
+  min-height: 0;
+  height: 80vw;
+  max-height: 80vh;
 `;
 
 interface Props {

--- a/src/client/components/ScrollToTop.tsx
+++ b/src/client/components/ScrollToTop.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { withRouter, match } from 'react-router';
+import * as H from 'history';
+
+interface Props {
+  match: match<any>;
+  location: H.Location;
+  history: H.History;
+}
+
+class ScrollToTop extends React.Component<Props> {
+  componentDidMount() {
+    window.scrollTo(0, 0);
+  }
+
+  render() {
+    return this.props.children;
+  }
+}
+
+export default withRouter(ScrollToTop);

--- a/src/client/pages/PortfolioDetailPage.tsx
+++ b/src/client/pages/PortfolioDetailPage.tsx
@@ -11,6 +11,7 @@ import PortfolioDetailSVG from '../components/Portfolio/PortfolioDetailSVG';
 import PortfolioDetailBackground from '../components/Portfolio/PortfolioDetailBackground';
 import PortfolioDetailGallery from '../components/Portfolio/PortfolioDetailGallery';
 import PortfolioDetailHero from '../components/Portfolio/PortfolioDetailHero';
+import ScrollToTop from '../components/ScrollToTop';
 import {
   getGalleryImages,
   getBackgroundImage,
@@ -54,34 +55,36 @@ export class PortfolioDetailPage extends React.Component<Props, {}> {
     const bgImage = getBackgroundImage(this.props.portfolio.imagePaths);
 
     return (
-      <div className={this.props.className}>
-        <Helmet>
-          <title>{this.props.portfolio.title}</title>
-          <meta property="og:title" content={this.props.portfolio.title} />
-        </Helmet>
-        {!heroImage &&
-          bgImage && (
-            <PortfolioDetailBackground
-              imagePath={bgImage.originalUrl}
-              styles={bgImage.meta && bgImage.meta.backgroundStyles}
-            />
-          )}
-        <div className="content">
-          <Header />
-          {heroImage && (
-            <PortfolioDetailHero
-              imagePath={heroImage.originalUrl}
-              title={this.props.portfolio.title}
-              description={this.props.portfolio.description}
-              hideTitle={
-                this.props.portfolio.meta &&
-                !this.props.portfolio.meta.showTitle
-              }
-            />
-          )}
-          {this.getDetailView(this.props.portfolio)}
+      <ScrollToTop>
+        <div className={this.props.className}>
+          <Helmet>
+            <title>{this.props.portfolio.title}</title>
+            <meta property="og:title" content={this.props.portfolio.title} />
+          </Helmet>
+          {!heroImage &&
+            bgImage && (
+              <PortfolioDetailBackground
+                imagePath={bgImage.originalUrl}
+                styles={bgImage.meta && bgImage.meta.backgroundStyles}
+              />
+            )}
+          <div className="content">
+            <Header />
+            {heroImage && (
+              <PortfolioDetailHero
+                imagePath={heroImage.originalUrl}
+                title={this.props.portfolio.title}
+                description={this.props.portfolio.description}
+                hideTitle={
+                  this.props.portfolio.meta &&
+                  !this.props.portfolio.meta.showTitle
+                }
+              />
+            )}
+            {this.getDetailView(this.props.portfolio)}
+          </div>
         </div>
-      </div>
+      </ScrollToTop>
     );
   }
 }

--- a/src/client/styles/base.ts
+++ b/src/client/styles/base.ts
@@ -77,5 +77,9 @@ export default `
     vertical-align: middle;
     border: 0;
   }
+
+  blockquote {
+    margin: 0;
+  }
 `;
 /* tslint:enable max-line-length */

--- a/src/client/utils/makeTypeComponent.tsx
+++ b/src/client/utils/makeTypeComponent.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import styled, { StyledComponentClass } from 'styled-components';
 import { type, scalableType } from '../styles/mixins';
 
-export interface Props {
+export interface Props extends React.HTMLProps<HTMLDivElement> {
   className?: string;
   tag: Tag;
   scale?: boolean;


### PR DESCRIPTION
* Fixes spacing in header area
* Adds additional `apple-mobile-*` meta properties - although they seem to be ignored at the moment
* Fixes height of portfolio detail hero
* Adds scroll to top behavior when visiting the detail pages
* Adds ability to apply normal HTML attributes/props to `Type` components
* Adds basic styling for `blockquote` on detail page

Fixes #86 