### PR TITLE
Invalidate SW caching at build time

### DIFF
--- a/src/client/sw.ts
+++ b/src/client/sw.ts
@@ -8,7 +8,7 @@ import {
 } from './utils/swCache';
 import { FONT_URL } from './styles/vars';
 
-const CACHE_VERSION = 2;
+const CACHE_VERSION = process.env.SW_ID || 'UNKNOWN';
 const CACHE_NAME = composeCacheName(CACHE_VERSION);
 const OFFLINE_IMAGE_PLACEHOLDER = '/offline.svg';
 const HOMEPAGE = '/';
@@ -39,6 +39,7 @@ const CACHED_FILES: string[] = [
 ];
 
 self.addEventListener('install', (e: Event) => {
+  skipWaiting();
   const event = e as ServiceWorkerEvent;
   (event as ExtendableEvent).waitUntil(
     caches.open(CACHE_NAME).then(cache => {

--- a/src/client/utils/__tests__/swCache.test.ts
+++ b/src/client/utils/__tests__/swCache.test.ts
@@ -2,7 +2,7 @@ import * as swCache from '../swCache';
 
 describe('composeCacheName', () => {
   it('composes a cache name based on a version number', () => {
-    const result = swCache.composeCacheName(42);
+    const result = swCache.composeCacheName('42');
 
     expect(result).toEqual('syn-cache-v42');
   });

--- a/src/client/utils/swCache.ts
+++ b/src/client/utils/swCache.ts
@@ -1,6 +1,6 @@
 export const CACHE_PREFIX = 'syn-cache-v';
 
-export const composeCacheName = (version: number) =>
+export const composeCacheName = (version: string) =>
   `${CACHE_PREFIX}${version}`;
 
 export const getMatchingCachedResponseWithCache = (activeCacheName: string) => (

--- a/webpack.client.js
+++ b/webpack.client.js
@@ -86,4 +86,19 @@ const config = {
   ],
 };
 
-module.exports = merge(baseConfig, config);
+const prodConfig = {
+  output: {
+    filename: '[name].[chunkhash].js',
+    path: path.resolve(__dirname, 'public'),
+    publicPath: '/',
+  },
+}
+
+module.exports = (env, {
+  mode
+}) => {
+  if (mode === 'production') {
+    return merge(baseConfig, config, prodConfig);
+  }
+  return merge(baseConfig, config);
+}

--- a/webpack.client.js
+++ b/webpack.client.js
@@ -7,6 +7,10 @@ const ServiceWorkerWebpackPlugin = require('serviceworker-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const ImageminPlugin = require('imagemin-webpack-plugin').default;
 
+const envPlugin = new webpack.DefinePlugin({
+  'process.env.SW_ID': JSON.stringify((new Date()).toISOString()),
+});
+
 const indexPage = new HtmlWebpackPlugin({
   template: `!!raw-loader!${path.join(
     process.cwd(),
@@ -37,8 +41,7 @@ const serviceWorker = new ServiceWorkerWebpackPlugin({
   entry: path.join(__dirname, 'src/client/sw.ts'),
 });
 
-const copyWebpackPlugin = new CopyWebpackPlugin([
-  {
+const copyWebpackPlugin = new CopyWebpackPlugin([{
     from: 'src/client/images',
     to: '',
   },
@@ -79,6 +82,7 @@ const config = {
     serviceWorker,
     copyWebpackPlugin,
     imageMinPlugin,
+    envPlugin,
   ],
 };
 


### PR DESCRIPTION
* Create unique SW cache name based from build environment
* Use `skipWaiting()` within SW so the SW doesn't need to wait to activate
* Add `[chunkhash]` to production client file names

Fixes #93 
