### PR TITLE
Optimize bundles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,10 @@ notifications:
   email: false
 script:
   - npm run validate
+deploy:
+- provider: script
+    script: now --token $NOW_TOKEN && now alias --token $NOW_TOKEN
+    skip_cleanup: true
+    on:
+      master: true
+# https://zeit.co/docs/continuous-integration/travis

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ This repository is my personal portfolio, resume, and playground where I experim
 npm run dev
 ```
 
+#### Running the client locally with a service worker
+
+By default, the service worker is only invoked in a production environment. This typically done by running `npm run prod:build-client`. However, you can force the service worker to run in a dev environment by running `npm run dev:build-client -- --env.serviceWorker=true`.
+
 #### Run development server with VS Code debugging
 
 You'll need to run the client and server builds in watch mode as two separate tasks
@@ -57,4 +61,10 @@ npm run dev:watch-server
 ```
 npm run build
 npm start
+```
+
+### Analyzing Client Bundle
+
+```
+npm run prod:build-client -- --env.analyze=true
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1413,6 +1413,17 @@
       "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
       "dev": true
     },
+    "bfj-node4": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/bfj-node4/-/bfj-node4-5.3.1.tgz",
+      "integrity": "sha512-SOmOsowQWfXc7ybFARsK3C4MCOWzERaOMV/Fl3Tgjs+5dJWyzo3oa127jL44eMbQiAN17J7SvAs2TRxEScTUmg==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.5.1",
+        "check-types": "^7.3.0",
+        "tryer": "^1.0.0"
+      }
+    },
     "big.js": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
@@ -2027,6 +2038,12 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.5.0.tgz",
       "integrity": "sha512-9ZTaoBaePSCFvNlNGrsyI8ZVACP2svUtq0DkM7t4K2ClAa96sqOIRjAzDTc8zXzFt1cZR46rRzLTiHFSJ+Qw0g==",
+      "dev": true
+    },
+    "check-types": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/check-types/-/check-types-7.4.0.tgz",
+      "integrity": "sha512-YbulWHdfP99UfZ73NcUDlNJhEIDgm9Doq9GhpyXbF+7Aegi3CVV7qqMCKTTqJxlvEvnQBp9IA+dxsGN6xK/nSg==",
       "dev": true
     },
     "cheerio": {
@@ -4326,6 +4343,12 @@
         "minimatch": "^3.0.3"
       }
     },
+    "filesize": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
+      "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
+      "dev": true
+    },
     "fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -5597,6 +5620,24 @@
       "dev": true,
       "requires": {
         "glogg": "^1.0.0"
+      }
+    },
+    "gzip-size": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-4.1.0.tgz",
+      "integrity": "sha1-iuCWJX6r59acRb4rZ8RIEk/7UXw=",
+      "dev": true,
+      "requires": {
+        "duplexer": "^0.1.1",
+        "pify": "^3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
       }
     },
     "handlebars": {
@@ -9990,6 +10031,12 @@
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
+    "opener": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.0.tgz",
+      "integrity": "sha512-MD4s/o61y2slS27zm2s4229V2gAUHX0/e3/XOmY/jsXwhysjjCIHN8lx7gqZCrZk19ym+HjCUWHeMKD7YJtKCQ==",
+      "dev": true
+    },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
@@ -13169,6 +13216,12 @@
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
+    "tryer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
+      "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==",
+      "dev": true
+    },
     "ts-jest": {
       "version": "22.4.6",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-22.4.6.tgz",
@@ -14263,6 +14316,69 @@
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
           "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
           "dev": true
+        }
+      }
+    },
+    "webpack-bundle-analyzer": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-2.13.1.tgz",
+      "integrity": "sha512-rwxyfecTAxoarCC9VlHlIpfQCmmJ/qWD5bpbjkof+7HrNhTNZIwZITxN6CdlYL2axGmwNUQ+tFgcSOiNXMf/sQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "^5.3.0",
+        "bfj-node4": "^5.2.0",
+        "chalk": "^2.3.0",
+        "commander": "^2.13.0",
+        "ejs": "^2.5.7",
+        "express": "^4.16.2",
+        "filesize": "^3.5.11",
+        "gzip-size": "^4.1.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "opener": "^1.4.3",
+        "ws": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "commander": {
+          "version": "2.17.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "syn-by-design",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syn-by-design",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Eric Masiello's portfolio",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "tslint-react": "~3.5.1",
     "typescript": "^2.8.4",
     "webpack": "^4.16.5",
+    "webpack-bundle-analyzer": "^2.13.1",
     "webpack-cli": "~3.1.0",
     "webpack-merge": "~4.1.4",
     "webpack-node-externals": "~1.7.2"

--- a/src/client/Chrome.tsx
+++ b/src/client/Chrome.tsx
@@ -6,6 +6,7 @@ import * as tinyColor from 'tinycolor2';
 import base from './styles/base';
 import { PAGE, COLORS, pageBorderWidth } from './styles/vars';
 import { pxToRem } from './styles/utils';
+import * as packageJSON from '../../package.json';
 
 injectGlobal`
   ${base}
@@ -17,8 +18,18 @@ interface Props
   portfolio?: Portfolio;
 }
 
+const Version = styled.small`
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  padding: ${pxToRem(2)} ${pxToRem(4)} 0;
+`;
+
 const Chrome: React.SFC<Props> = ({ children, className }) => (
-  <div className={className}>{children}</div>
+  <div className={className}>
+    {children}
+    <Version>v{packageJSON.version}</Version>
+  </div>
 );
 
 function mapStateToProps(state: AppState, props: Props) {
@@ -35,17 +46,30 @@ function mapStateToProps(state: AppState, props: Props) {
   return props;
 }
 
-export default styled(connect(mapStateToProps)(Chrome))`
-  ${({ portfolio }) => {
-    let color = tinyColor(COLORS.highlight)
-      .setAlpha(0.8)
-      .toRgbString();
-    if (portfolio && portfolio.meta && portfolio.meta.highlightColor) {
-      color = portfolio.meta.highlightColor;
-    }
-    return `border: ${pageBorderWidth} solid ${color};`;
-  }};
+const getThemeColor = (props: { portfolio?: Portfolio }) => {
+  if (
+    props.portfolio &&
+    props.portfolio.meta &&
+    props.portfolio.meta.highlightColor
+  ) {
+    return props.portfolio.meta.highlightColor;
+  }
+  return tinyColor(COLORS.highlight)
+    .setAlpha(0.8)
+    .toRgbString();
+};
+
+const StyledChrome = styled(Chrome)`
+  ${props => `border: ${pageBorderWidth} solid ${getThemeColor(props)};`};
   padding-bottom: ${pxToRem(PAGE.bottomPadding)};
   min-height: 100vh;
   transition: border-color 1s;
+  position: relative;
+
+  ${Version} {
+    ${props => `background-color: ${getThemeColor(props)};`};
+    color: ${COLORS.bg};
+  }
 `;
+
+export default connect(mapStateToProps)(StyledChrome);

--- a/src/client/pages/HomePage.tsx
+++ b/src/client/pages/HomePage.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import styled from 'styled-components';
 import { Store } from 'redux';
 import { connect } from 'react-redux';
-import isEmpty from 'lodash-es/isEmpty';
 import Hero from '../components/Hero';
 import PortfolioGallery from '../components/Portfolio/PortfolioGallery';
 import Header from '../components/HeaderOnline';
@@ -38,7 +37,7 @@ export class HomePage extends React.Component<Props, {}> {
     if (this.props.portfolioItems.length <= 1) {
       this.loadInitialPortfolioPage();
     }
-    if (isEmpty(this.props.resume)) {
+    if (Object.keys(this.props.resume).length === 0) {
       this.props.fetchResume();
     }
 

--- a/src/client/state/portfolio/__tests__/reducers.test.ts
+++ b/src/client/state/portfolio/__tests__/reducers.test.ts
@@ -1,0 +1,413 @@
+import * as reducers from '../reducers';
+import * as types from '../types';
+import { AnyAction } from 'redux';
+
+describe('portfolioMetaReducer', () => {
+  test('should return a default object when initializing', () => {
+    // @ts-ignore
+    const result = reducers.portfolioMetaReducer(undefined, {});
+
+    expect(result).toEqual({
+      currentPageNumber: 0,
+      filterCategories: '',
+      filterSearchTerm: '',
+      filterTags: '',
+      pageSize: 0,
+      totalPages: 0,
+    });
+  });
+
+  test('should return a parsed object if action is FETCH_PORTFOLIO_ITEMS and there is no error', () => {
+    const action: AnyAction = {
+      type: types.FETCH_PORTFOLIO_ITEMS,
+      meta: {
+        _currentpagenumber: 1,
+        _pagesize: 2,
+        _totalpages: 4,
+        _filtercategories: 'foo',
+        _filtertags: 'tag1, tag2',
+        _filtersearchterm: 'search term',
+      },
+    };
+    const result = reducers.portfolioMetaReducer(
+      reducers.defaultPortfolioMeta,
+      action,
+    );
+
+    expect(result).toEqual({
+      currentPageNumber: 1,
+      filterCategories: 'foo',
+      filterSearchTerm: 'search term',
+      filterTags: 'tag1, tag2',
+      pageSize: 2,
+      totalPages: 4,
+    });
+  });
+
+  test('should return initial state if there is an error', () => {
+    const result = reducers.portfolioMetaReducer(
+      reducers.defaultPortfolioMeta,
+      {
+        type: types.FETCH_PORTFOLIO_DETAIL,
+        error: true,
+      },
+    );
+
+    expect(result).toEqual(reducers.defaultPortfolioMeta);
+  });
+});
+
+describe('portfolioReducer', () => {
+  test('should return a default object when initializing', () => {
+    // @ts-ignore
+    const result = reducers.portfolioReducer(undefined, {});
+
+    expect(result).toEqual([]);
+  });
+
+  describe('FETCH_PORTFOLIO_ITEMS', () => {
+    describe('with error', () => {
+      test('should return initial state', () => {
+        const result = reducers.portfolioReducer([], {
+          type: types.FETCH_PORTFOLIO_DETAIL,
+          error: true,
+          payload: ['foo', 'bar'],
+        });
+
+        expect(result).toEqual([]);
+      });
+    });
+
+    describe('no errors', () => {
+      test('should add new items but ignore duplicates', () => {
+        const initialState: Portfolio[] = [
+          {
+            id: 'sigma',
+            title: 'Sigma Performance Group',
+            description: 'sigmaperfgroup',
+            meta: {
+              stackDesign: false,
+              websiteUrl: '',
+              isSVG: false,
+              thumb: {
+                column: 'span 1',
+                row: 'span 2',
+                position: '0 100%',
+              },
+            },
+            category: ['web'],
+            tags: ['(X)HTML', 'CSS', 'Design/Branding', 'PHP'],
+            imagePaths: [
+              {
+                originalUrl: `sigmaperfgroup-original.jpg`,
+                largeUrl: `sigmaperfgroup-700px.jpg`,
+                mediumUrl: `sigmaperfgroup-450px.jpg`,
+                thumbUrl: `sigmaperfgroup-200px.jpg`,
+                title: '',
+                description: '',
+                priority: 0,
+              },
+            ],
+          },
+          {
+            id: 'incognito',
+            title: 'Incognito Logo',
+            description:
+              'Logo for Incognito electronic events and production service',
+            meta: {
+              stackDesign: false,
+              websiteUrl: '',
+              isSVG: false,
+              thumb: {
+                position: '0 100%',
+              },
+            },
+            category: ['logos'],
+            tags: [],
+            imagePaths: [
+              {
+                originalUrl: `incognito-original.jpg`,
+                largeUrl: `incognito-700px.jpg`,
+                mediumUrl: `incognito-450px.jpg`,
+                thumbUrl: `incognito-200px.jpg`,
+                title: '',
+                description: '',
+                priority: 0,
+              },
+            ],
+          },
+        ];
+
+        const result = reducers.portfolioReducer(initialState, {
+          type: types.FETCH_PORTFOLIO_ITEMS,
+          payload: {
+            data: [
+              {
+                id: 'incognito-2',
+                title: 'Incognito Logo 2',
+                description:
+                  'Logo for Incognito electronic events and production service',
+                meta: {
+                  stackDesign: false,
+                  websiteUrl: '',
+                  isSVG: false,
+                  thumb: {
+                    position: '0 100%',
+                  },
+                },
+                category: ['logos'],
+                tags: [],
+                imagePaths: [
+                  {
+                    originalUrl: `incognito-2-original.jpg`,
+                    largeUrl: `incognito-2-700px.jpg`,
+                    mediumUrl: `incognito-2-450px.jpg`,
+                    thumbUrl: `incognito-2-200px.jpg`,
+                    title: '',
+                    description: '',
+                    priority: 0,
+                  },
+                ],
+              },
+              {
+                id: 'incognito',
+                title: 'Incognito Logo',
+                description:
+                  'Logo for Incognito electronic events and production service',
+                meta: {
+                  stackDesign: false,
+                  websiteUrl: '',
+                  isSVG: false,
+                  thumb: {
+                    position: '0 100%',
+                  },
+                },
+                category: ['logos'],
+                tags: [],
+                imagePaths: [
+                  {
+                    originalUrl: `incognito-original.jpg`,
+                    largeUrl: `incognito-700px.jpg`,
+                    mediumUrl: `incognito-450px.jpg`,
+                    thumbUrl: `incognito-200px.jpg`,
+                    title: '',
+                    description: '',
+                    priority: 0,
+                  },
+                ],
+              },
+            ],
+          },
+        });
+
+        expect(result).toHaveLength(3);
+      });
+    });
+  });
+
+  describe('FETCH_PORTFOLIO_DETAIL', () => {
+    describe('with error', () => {
+      test('should return initial state', () => {
+        const result = reducers.portfolioReducer([], {
+          type: types.FETCH_PORTFOLIO_DETAIL,
+          error: true,
+          payload: ['foo', 'bar'],
+        });
+
+        expect(result).toEqual([]);
+      });
+    });
+
+    describe('no errors', () => {
+      test('should add the new item when it does not exist in the initial state', () => {
+        const initialState: Portfolio[] = [
+          {
+            id: 'sigma',
+            title: 'Sigma Performance Group',
+            description: 'sigmaperfgroup',
+            meta: {
+              stackDesign: false,
+              websiteUrl: '',
+              isSVG: false,
+              thumb: {
+                column: 'span 1',
+                row: 'span 2',
+                position: '0 100%',
+              },
+            },
+            category: ['web'],
+            tags: ['(X)HTML', 'CSS', 'Design/Branding', 'PHP'],
+            imagePaths: [
+              {
+                originalUrl: `sigmaperfgroup-original.jpg`,
+                largeUrl: `sigmaperfgroup-700px.jpg`,
+                mediumUrl: `sigmaperfgroup-450px.jpg`,
+                thumbUrl: `sigmaperfgroup-200px.jpg`,
+                title: '',
+                description: '',
+                priority: 0,
+              },
+            ],
+          },
+          {
+            id: 'incognito',
+            title: 'Incognito Logo',
+            description:
+              'Logo for Incognito electronic events and production service',
+            meta: {
+              stackDesign: false,
+              websiteUrl: '',
+              isSVG: false,
+              thumb: {
+                position: '0 100%',
+              },
+            },
+            category: ['logos'],
+            tags: [],
+            imagePaths: [
+              {
+                originalUrl: `incognito-original.jpg`,
+                largeUrl: `incognito-700px.jpg`,
+                mediumUrl: `incognito-450px.jpg`,
+                thumbUrl: `incognito-200px.jpg`,
+                title: '',
+                description: '',
+                priority: 0,
+              },
+            ],
+          },
+        ];
+
+        const result = reducers.portfolioReducer(initialState, {
+          type: types.FETCH_PORTFOLIO_DETAIL,
+          payload: {
+            data: {
+              id: 'incognito-2',
+              title: 'Incognito Logo 2',
+              description:
+                'Logo for Incognito electronic events and production service',
+              meta: {
+                stackDesign: false,
+                websiteUrl: '',
+                isSVG: false,
+                thumb: {
+                  position: '0 100%',
+                },
+              },
+              category: ['logos'],
+              tags: [],
+              imagePaths: [
+                {
+                  originalUrl: `incognito-2-original.jpg`,
+                  largeUrl: `incognito-2-700px.jpg`,
+                  mediumUrl: `incognito-2-450px.jpg`,
+                  thumbUrl: `incognito-2-200px.jpg`,
+                  title: '',
+                  description: '',
+                  priority: 0,
+                },
+              ],
+            },
+          },
+        });
+
+        expect(result).toHaveLength(3);
+      });
+
+      test('should ignore the items that already exist in initial state', () => {
+        const initialState: Portfolio[] = [
+          {
+            id: 'sigma',
+            title: 'Sigma Performance Group',
+            description: 'sigmaperfgroup',
+            meta: {
+              stackDesign: false,
+              websiteUrl: '',
+              isSVG: false,
+              thumb: {
+                column: 'span 1',
+                row: 'span 2',
+                position: '0 100%',
+              },
+            },
+            category: ['web'],
+            tags: ['(X)HTML', 'CSS', 'Design/Branding', 'PHP'],
+            imagePaths: [
+              {
+                originalUrl: `sigmaperfgroup-original.jpg`,
+                largeUrl: `sigmaperfgroup-700px.jpg`,
+                mediumUrl: `sigmaperfgroup-450px.jpg`,
+                thumbUrl: `sigmaperfgroup-200px.jpg`,
+                title: '',
+                description: '',
+                priority: 0,
+              },
+            ],
+          },
+          {
+            id: 'incognito',
+            title: 'Incognito Logo',
+            description:
+              'Logo for Incognito electronic events and production service',
+            meta: {
+              stackDesign: false,
+              websiteUrl: '',
+              isSVG: false,
+              thumb: {
+                position: '0 100%',
+              },
+            },
+            category: ['logos'],
+            tags: [],
+            imagePaths: [
+              {
+                originalUrl: `incognito-original.jpg`,
+                largeUrl: `incognito-700px.jpg`,
+                mediumUrl: `incognito-450px.jpg`,
+                thumbUrl: `incognito-200px.jpg`,
+                title: '',
+                description: '',
+                priority: 0,
+              },
+            ],
+          },
+        ];
+
+        const result = reducers.portfolioReducer(initialState, {
+          type: types.FETCH_PORTFOLIO_DETAIL,
+          payload: {
+            data: {
+              id: 'incognito',
+              title: 'Incognito Logo',
+              description:
+                'Logo for Incognito electronic events and production service',
+              meta: {
+                stackDesign: false,
+                websiteUrl: '',
+                isSVG: false,
+                thumb: {
+                  position: '0 100%',
+                },
+              },
+              category: ['logos'],
+              tags: [],
+              imagePaths: [
+                {
+                  originalUrl: `incognito-original.jpg`,
+                  largeUrl: `incognito-700px.jpg`,
+                  mediumUrl: `incognito-450px.jpg`,
+                  thumbUrl: `incognito-200px.jpg`,
+                  title: '',
+                  description: '',
+                  priority: 0,
+                },
+              ],
+            },
+          },
+        });
+
+        expect(result).toHaveLength(2);
+      });
+    });
+  });
+});

--- a/src/client/state/portfolio/reducers.ts
+++ b/src/client/state/portfolio/reducers.ts
@@ -2,7 +2,7 @@ import { Reducer } from 'redux';
 import uniqBy from 'lodash-es/uniqBy';
 import * as types from './types';
 
-const defaultPortfolioMeta: UIPortfolioMeta = {
+export const defaultPortfolioMeta: UIPortfolioMeta = {
   currentPageNumber: 0,
   pageSize: 0,
   totalPages: 0,

--- a/src/client/state/portfolio/reducers.ts
+++ b/src/client/state/portfolio/reducers.ts
@@ -31,36 +31,23 @@ export const portfolioMetaReducer: Reducer<UIPortfolioMeta> = (
 };
 
 const dedupePortfolioItems = (
-  portfolioWithPossibleDuplicates: Portfolio[],
-): Portfolio[] => {
-  interface PortfolioMap {
-    [x: string]: number;
-  }
-
-  const uniqueMap = portfolioWithPossibleDuplicates.reduce(
+  portfolioWithPossibleDuplicates: Portfolio[] = [],
+): Portfolio[] =>
+  portfolioWithPossibleDuplicates.reduce(
     (acc, item) => {
-      if (!acc[item.id]) {
-        acc[item.id] = 0;
-      }
-      return acc;
-    },
-    {} as PortfolioMap,
-  );
-
-  return portfolioWithPossibleDuplicates.reduce(
-    (acc, item) => {
-      if (acc.counts[item.id] === 0) {
+      if (!acc.added[item.id]) {
         acc.items.push(item);
-        acc.counts[item.id] = 1;
+        acc.added[item.id] = true;
       }
       return acc;
     },
     {
       items: [] as Portfolio[],
-      counts: uniqueMap,
+      added: {} as {
+        [x: string]: boolean;
+      },
     },
   ).items;
-};
 
 export const portfolioReducer: Reducer<Portfolio[]> = (state = [], action) => {
   if (action.type === types.FETCH_PORTFOLIO_ITEMS && !action.error) {

--- a/src/client/state/portfolio/reducers.ts
+++ b/src/client/state/portfolio/reducers.ts
@@ -33,6 +33,7 @@ export const portfolioMetaReducer: Reducer<UIPortfolioMeta> = (
 
 export const portfolioReducer: Reducer<Portfolio[]> = (state = [], action) => {
   if (action.type === types.FETCH_PORTFOLIO_ITEMS && !action.error) {
+    // TODO: remove uniqBy
     return uniqBy([...state, ...action.payload.data], 'id');
   }
 

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -13,6 +13,11 @@ declare module '*.svg' {
   export = value;
 }
 
+declare module '*.json' {
+  const value: any;
+  export = value;
+}
+
 declare module 'mixpanel-browser' {
   interface Mixpanel {
     init: (token: string) => void;

--- a/webpack.client.js
+++ b/webpack.client.js
@@ -6,6 +6,8 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ServiceWorkerWebpackPlugin = require('serviceworker-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const ImageminPlugin = require('imagemin-webpack-plugin').default;
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer')
+  .BundleAnalyzerPlugin;
 const now = require('./now.json');
 
 module.exports = (env = {}, { mode }) => {
@@ -65,6 +67,19 @@ module.exports = (env = {}, { mode }) => {
     test: /\.(jpe?g|png|gif|svg)$/i,
   });
 
+  const plugins = [
+    indexPage,
+    errorPage,
+    serviceWorker,
+    copyWebpackPlugin,
+    imageMinPlugin,
+    envPlugin,
+  ];
+
+  if (env.analyze === 'true') {
+    plugins.push(new BundleAnalyzerPlugin());
+  }
+
   const config = {
     // Tell webpack the root file of our
     // server application
@@ -95,14 +110,7 @@ module.exports = (env = {}, { mode }) => {
       ],
     },
 
-    plugins: [
-      indexPage,
-      errorPage,
-      serviceWorker,
-      copyWebpackPlugin,
-      imageMinPlugin,
-      envPlugin,
-    ],
+    plugins,
   };
 
   const prodConfig = {

--- a/webpack.client.js
+++ b/webpack.client.js
@@ -80,12 +80,6 @@ module.exports = (env = {}, { mode }) => {
       publicPath: '/',
     },
 
-    optimization: {
-      splitChunks: {
-        chunks: 'all',
-      },
-    },
-
     module: {
       rules: [
         {


### PR DESCRIPTION
- Add bundle analyzer
- Remove usage of lodash on the client side
- Add tests for portfolio reducers
- Add instructions to README for running analyze and working with service workers locally
- Configure `.travis.yml` to deploy to now automatically when merged to master
- Output version number in footer
- Fix bug where it wasn't applying the correct page border color