### PR TITLE
Add contact to resume

### DIFF
--- a/cypress/e2e/e2e/homepage.spec.ts
+++ b/cypress/e2e/e2e/homepage.spec.ts
@@ -18,7 +18,7 @@ function terminalLog(violations) {
   cy.task('table', violationData);
 }
 
-context('Tour', () => {
+context('Homepage', () => {
   beforeEach(() => {
     cy.visit('/');
     // Inject the axe-core library

--- a/cypress/e2e/e2e/homepage.spec.ts
+++ b/cypress/e2e/e2e/homepage.spec.ts
@@ -62,4 +62,20 @@ context('Homepage', () => {
 
     cy.get('#resume').contains(/eric masiello/i);
   });
+
+  context('Resume', () => {
+    it('should not display my email address in the resume header', () => {
+      cy.get('[data-cy="resume"] a[href*="mailto:eric.j.masiello@gmail.com"]').should('not.exist');
+    });
+
+    it('should not display my website address in the resume header', () => {
+      cy.get('[data-cy="resume"] a').contains('synbydesign.com').should('not.exist');
+    });
+
+    it('should not display [a/my] phone number in the header', () => {
+      cy.get('[data-cy="resume"] a')
+        .contains(/^(\+\d{1,2}\s)?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}$/)
+        .should('not.exist');
+    });
+  });
 });

--- a/cypress/e2e/e2e/resume.spec.ts
+++ b/cypress/e2e/e2e/resume.spec.ts
@@ -15,6 +15,16 @@ it('should contain an email contact in the header', () => {
   cy.get('header a[href*="mailto:eric.j.masiello@gmail.com"]').should('exist');
 });
 
+it('should display my website address in the header', () => {
+  cy.get('header a').contains('synbydesign.com').should('exist');
+});
+
+it('should display [a/my] phone number in the header', () => {
+  cy.get('header')
+    .contains(/^(\+\d{1,2}\s)?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}$/)
+    .should('exist');
+});
+
 it('passes visual regression', () => {
   cy.percySnapshot('Resume Page', { widths: [375, 768, 992, 1200] });
 });

--- a/cypress/e2e/helpers/axe.ts
+++ b/cypress/e2e/helpers/axe.ts
@@ -1,0 +1,35 @@
+import { AxeResults } from 'axe-core';
+import { Options } from 'cypress-axe';
+
+// https://www.deque.com/axe/core-documentation/api-documentation/#axe-core-tags
+export const axeRunOptions: Options = {
+  runOnly: {
+    type: 'tag',
+    values: ['wcag2a', 'wcag21a', 'wcag2aa', 'wcag21aa'],
+  },
+};
+
+export function terminalLog(violations: AxeResults['violations']) {
+  cy.task(
+    'log',
+    `\n${violations.length} accessibility violation${violations.length === 1 ? '' : 's'} ${
+      violations.length === 1 ? 'was' : 'were'
+    } detected:\n`
+  );
+
+  const violationData = violations.map(({ id, impact, description, nodes }) => ({
+    id,
+    impact,
+    description,
+    nodes: nodes.length,
+  }));
+  cy.task('table', violationData);
+
+  const violationIdToNodesMap = violations.reduce<Record<string, string[]>>((aggregate, violation) => {
+    return {
+      ...aggregate,
+      [violation.id]: violation.nodes.map((n) => n.html),
+    };
+  }, {});
+  cy.task('log', `\nOffending nodes: ${JSON.stringify(violationIdToNodesMap, null, 2)} \n`);
+}

--- a/cypress/e2e/homepage.spec.ts
+++ b/cypress/e2e/homepage.spec.ts
@@ -1,28 +1,10 @@
 /// <reference types="cypress" />
 
-function terminalLog(violations) {
-  cy.task(
-    'log',
-    `${violations.length} accessibility violation${violations.length === 1 ? '' : 's'} ${
-      violations.length === 1 ? 'was' : 'were'
-    } detected`
-  );
-  // pluck specific keys to keep the table readable
-  const violationData = violations.map(({ id, impact, description, nodes }) => ({
-    id,
-    impact,
-    description,
-    nodes: nodes.length,
-  }));
-
-  cy.task('table', violationData);
-}
+import { axeRunOptions, terminalLog } from './helpers/axe';
 
 context('Homepage', () => {
   beforeEach(() => {
     cy.visit('/');
-    // Inject the axe-core library
-    cy.injectAxe();
   });
 
   it('passes visual regression', () => {
@@ -30,17 +12,9 @@ context('Homepage', () => {
   });
 
   it('is accessible', () => {
-    // first a11y test
-    cy.checkA11y(
-      null,
-      {
-        runOnly: {
-          type: 'tag',
-          values: ['wcag2a', 'wcag21a', 'wcag2aa', 'wcag21aa'],
-        },
-      },
-      terminalLog
-    );
+    // Inject the axe-core library
+    cy.injectAxe();
+    cy.checkA11y(null, axeRunOptions, terminalLog);
   });
 
   it('should have a title', () => {

--- a/cypress/e2e/privacy.spec.ts
+++ b/cypress/e2e/privacy.spec.ts
@@ -1,3 +1,5 @@
+import { axeRunOptions, terminalLog } from './helpers/axe';
+
 beforeEach(() => {
   cy.visit('/privacy');
 });
@@ -8,6 +10,12 @@ beforeEach(() => {
  */
 it('should exist', () => {
   cy.get('h1').contains(/privacy policy/i);
+});
+
+it('is accessible', () => {
+  // Inject the axe-core library
+  cy.injectAxe();
+  cy.checkA11y(null, axeRunOptions, terminalLog);
 });
 
 it('should contain an email contact', () => {

--- a/cypress/e2e/resume.spec.ts
+++ b/cypress/e2e/resume.spec.ts
@@ -1,3 +1,5 @@
+import { axeRunOptions, terminalLog } from './helpers/axe';
+
 beforeEach(() => {
   cy.visit('/resume');
 });
@@ -9,6 +11,12 @@ it('should exist', () => {
   cy.get('h1')
     .contains(/resume/i)
     .should('exist');
+});
+
+it('is accessible', () => {
+  // Inject the axe-core library
+  cy.injectAxe();
+  cy.checkA11y(null, axeRunOptions, terminalLog);
 });
 
 it('should contain an email contact in the header', () => {

--- a/src/components/homepage/Resume/Resume.astro
+++ b/src/components/homepage/Resume/Resume.astro
@@ -16,7 +16,7 @@ import ProfessionalExperience from './ProfessionalExperience.astro';
 import Talks from './Talks.astro';
 import EducationExperience from './EducationExperience.astro';
 import Wrapper from './Wrapper.astro';
-import { EMAIL } from '../../../config';
+import { EMAIL, PHONE, WEBSITE } from '../../../config';
 
 export interface Props extends Omit<astroHTML.JSX.BaseHTMLAttributes, 'slot'> {
   as?: keyof HTMLElementTagNameMap;
@@ -49,6 +49,8 @@ const classes = classNames('resume', format, className);
     ownerName={resume.name}
     ownerTitle={resume.title}
     email={format === 'print' ? EMAIL : undefined}
+    phone={format === 'print' ? PHONE : undefined}
+    websiteUrl={format === 'print' ? WEBSITE : undefined}
   />
   <section class="skills">
     <div>

--- a/src/components/homepage/Resume/Resume.astro
+++ b/src/components/homepage/Resume/Resume.astro
@@ -41,7 +41,7 @@ const { as: Element = 'div', class: className, format = 'web', ...rest } = Astro
 const classes = classNames('resume', format, className);
 ---
 
-<Element class={classes} {...rest}>
+<Element class={classes} {...rest} data-cy="resume">
   <ResumeHeader
     as={format === 'print' ? 'header' : 'hgroup'}
     class="lead"

--- a/src/components/homepage/Resume/ResumeHeader.astro
+++ b/src/components/homepage/Resume/ResumeHeader.astro
@@ -2,7 +2,6 @@
 import classNames from 'classnames';
 import H from '../../H.astro';
 import Text from '../../Text.astro';
-import { EMAIL } from '../../../config';
 
 export interface Props extends Omit<astroHTML.JSX.BaseHTMLAttributes, 'slot'> {
   as?: keyof HTMLElementTagNameMap;
@@ -10,21 +9,48 @@ export interface Props extends Omit<astroHTML.JSX.BaseHTMLAttributes, 'slot'> {
   ownerTitle: string;
   lead: string;
   email?: string;
+  phone?: string;
+  websiteUrl?: string;
 }
 
-const { as: Element = 'hgroup', ownerName, ownerTitle, lead, email, class: className, ...rest } = Astro.props;
+const {
+  as: Element = 'hgroup',
+  ownerName,
+  ownerTitle,
+  lead,
+  email,
+  phone,
+  websiteUrl,
+  class: className,
+  ...rest
+} = Astro.props;
 const classes = classNames('header', className);
-const nameClasses = classNames('name', { 'with-email': Boolean(email) });
+const websiteHost = websiteUrl ? new URL(websiteUrl).hostname : '';
+const nameClasses = classNames('name', { 'with-contact': Boolean(email) || Boolean(phone) || Boolean(websiteUrl) });
 ---
 
 <Element class={classes} {...rest}>
   <H level={4} as="h3" class={nameClasses}
     >{ownerName}
     {
-      email ? (
-        <Text as="a" href={`mailto:${EMAIL}`}>
-          {EMAIL}
-        </Text>
+      email || phone ? (
+        <div class="contact">
+          {email ? (
+            <Text as="a" href={`mailto:${email}`}>
+              {email}
+            </Text>
+          ) : null}
+          {phone ? (
+            <Text as="a" href={`tel:${phone}`}>
+              {phone}
+            </Text>
+          ) : null}
+          {websiteUrl ? (
+            <Text as="a" href={websiteUrl}>
+              {websiteHost}
+            </Text>
+          ) : null}
+        </div>
       ) : null
     }
   </H>
@@ -46,10 +72,10 @@ const nameClasses = classNames('name', { 'with-email': Boolean(email) });
     margin-bottom: 0;
   }
 
-  .name:where(.with-email) {
+  .name:where(.with-contact) {
     display: flex;
     justify-content: space-between;
-    align-items: baseline;
+    align-items: end;
   }
 
   a {
@@ -59,5 +85,18 @@ const nameClasses = classNames('name', { 'with-email': Boolean(email) });
   .title {
     margin-bottom: 0.25rem;
     color: var(--color-brand-invert);
+  }
+
+  .contact {
+    display: grid;
+    text-align: end;
+  }
+
+  .contact a:link {
+    text-decoration: none;
+  }
+
+  .contact a:is(:hover, :active) {
+    text-decoration: underline;
   }
 </style>

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,4 +10,4 @@ export const TWITTER = 'https://twitter.com/ericmasiello';
 export const EMAIL = 'eric.j.masiello@gmail.com';
 export const WEBSITE = 'https://synbydesign.com';
 // comes from .env
-export const PHONE = import.meta.env.SECRET_PHONE;
+export const PHONE = import.meta.env.SECRET_PHONE || '000-000-0000';

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,3 +8,6 @@ export const MEDIUM_BLOG = 'https://medium.com/@EricMasiello';
 export const LINKEDIN = 'https://www.linkedin.com/in/ericmasiello/';
 export const TWITTER = 'https://twitter.com/ericmasiello';
 export const EMAIL = 'eric.j.masiello@gmail.com';
+export const WEBSITE = 'https://synbydesign.com';
+// comes from .env
+export const PHONE = import.meta.env.SECRET_PHONE;

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -13,12 +13,17 @@ import VisuallyHidden from '../components/VisuallyHidden.astro';
   <body>
     <main>
       <VisuallyHidden as="h1" id="resume-title">Resume</VisuallyHidden>
-      <Resume id="resume" format="print" />
+      <Resume id="resume" format="print" class="resume" />
     </main>
     <style>
       :global(html) {
         --h-space: 2rem !important;
         font-size: 90% !important;
+      }
+
+      /* Styling uses on web-only version of page */
+      :global(body:not(:is(.PDF_GENERATION))) .resume {
+        padding-block-end: 3rem;
       }
     </style>
   </body>


### PR DESCRIPTION
- Adds contact details for my email and phone number to the `/resume` page (not available on the `/` route
- Phone number is available via a secret in Github
- Fixes minor styling issues on `/resume` route